### PR TITLE
fix: length byte의 길이가 0인 경우를 허용하던 것이 명세와 맞지 않아 수정

### DIFF
--- a/src/core/secs/converter/parser/parser.spec.ts
+++ b/src/core/secs/converter/parser/parser.spec.ts
@@ -38,6 +38,17 @@ describe('SecsParser Test', () => {
             const result: number = parser.parseByteLength(data);
             expect(result).toEqual(expected);
         });
+
+        it("length byte는 0이 될 수 없음", () => {
+            //근거: actual number of bytes in the message for one item is the item length plus 2, 3, 4 bytes for the item header
+            //header 길이가 최소 2라는 것은 length byte가 최소 1 byte라는 것
+
+            const data = 0b000000_00; // byte 길이 = 0
+            
+            expect(() => {
+                parser.parseByteLength(data);
+            }).toThrow();
+        })
     });
 
     describe('parseLength', () => {

--- a/src/core/secs/converter/parser/parser.ts
+++ b/src/core/secs/converter/parser/parser.ts
@@ -36,13 +36,16 @@ export class Secs2MessageParser {
     }
 
     /**
-     * secs-II 메시지의 byte length 정보를 파싱한다.
+     * secs-II 메시지의 byte length 정보를 파싱한다. 파싱한 값이 0이면 예외
      * @param data byte length 가 포함된 byte
      * @returns byte length 값
      */
     parseByteLength(data: number): number {
         const byteLengthMask = 0b000000_11;
-        return data & byteLengthMask;
+        const byteLength = data & byteLengthMask;
+
+        if(byteLength === 0) throw new Error("byte length must be in [1..3]");
+        return byteLength;
     }
 
     /**

--- a/tests/test-2.spec.ts
+++ b/tests/test-2.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  await page.goto('http://localhost:5173/');
+  await page.getByLabel('binary-editor_item-add').click();
+
+  // 입력을 다루는 코드
+  await page.getByLabel('binary-editor_item-add').pressSequentially('11111111');
+  
+  await expect(page.getByLabel('hex-editor_item-0')).toContainText('FF');
+  await page.getByRole('button', { name: 'parse' }).click();
+  await expect(page.getByLabel('result panel')).toContainText('error!');
+  await page.getByRole('button', { name: 'clear' }).click();
+  await expect(page.getByLabel('result panel')).toContainText('');
+});


### PR DESCRIPTION
SECS-I 명세에 따르면 Item의 헤더 길이는 2~4byte로 length byte가 최소 1byte 존재해야 하지만, 이 부분이 처리되지 않고 있었으므로 수정합니다.

# 근거
## 9.2
>  ... so the actual number of bytes in the messsage for one item is the item length plus 2, 3 or 4 bytes for the item header

format byte(1) + length byte(1~3)이 되어야만 item header 길이가 2 ~ 4 가 될 수 있다. 따라서 No. of length bytes가 1~3 사이의 값을 가져야 함을 유추할 수 있다.

## 9.2.1
> a zero-length in the format byte is illegal and produces error. A zero-length in the item length bytes has a special meaning as defined in te detailed message definition

9.2에서 설명한 내용을 정리한 것. format byte에 등장하는 길이는 0이면 안된다.