### PR TITLE
Refactor own router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,13 @@
         "@tailwindcss/vite": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router": "^7.2.0",
         "tailwindcss": "^4.0.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@playwright/test": "^1.50.1",
-        "@types/node": "^22.12.0",
+        "@types/node": "^22.13.5",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react-swc": "^3.5.0",
@@ -1956,12 +1955,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1976,9 +1969,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
-      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2695,15 +2688,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -4735,30 +4719,6 @@
       "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
       "license": "MIT"
     },
-    "node_modules/react-router": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.2.0.tgz",
-      "integrity": "sha512-fXyqzPgCPZbqhrk7k3hPcCpYIlQ2ugIXDboHUzhJISFVy2DEPsmHgN588MyGmkIOv3jDgNfUE3kJi83L28s/LQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/cookie": "^0.6.0",
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -4937,12 +4897,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5176,12 +5130,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,13 @@
     "@tailwindcss/vite": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.2.0",
     "tailwindcss": "^4.0.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@playwright/test": "^1.50.1",
-    "@types/node": "^22.12.0",
+    "@types/node": "^22.13.5",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,15 @@
-import { Route, Routes } from "react-router"
 import Main from "./layout/Main"
 import MainPage from "./page/main/MainPage"
 import EditItemPage from "./page/edit_item/EditItemPage"
+import Route from "./component/router/Route"
 
 function App() {
   return (
-    <Routes>
-      <Route element={<Main />}>
-        <Route index element={<MainPage />} />
-        <Route path="item-to-secs" element={<EditItemPage />} />
-      </Route>
-    </Routes>
+    <Main>
+      <Route path="/" element={<MainPage />} />
+      <Route path="/item-to-secs" element={<EditItemPage />} />
+    </Main>
+
   )
 }
 

--- a/src/component/router/Route.tsx
+++ b/src/component/router/Route.tsx
@@ -1,0 +1,16 @@
+import { useLinkStore } from "@/store/link";
+import React from "react";
+
+type RouteProps = {
+    path: string;
+    element: React.JSX.Element;
+}
+
+function Route({path, element}: RouteProps) {
+    const link = useLinkStore(it => it.link);
+
+    if(link !== path) return <></>;
+    return element;
+}
+
+export default Route;

--- a/src/layout/Main.tsx
+++ b/src/layout/Main.tsx
@@ -1,13 +1,16 @@
-import { Outlet } from "react-router";
 import Header from "./header/Header";
 import Navigation from "./header/nav/Navigation";
 
-function Main() {
+type MainProps = {
+    children?: React.ReactNode;
+}
+
+function Main({ children }: MainProps) {
     return <div className="w-full">
         <Header />
         <Navigation />
         <main className="p-2">
-            <Outlet/>
+            {children}
         </main>
         {/* <Footer /> */}
     </div>

--- a/src/layout/header/nav/Navigation.tsx
+++ b/src/layout/header/nav/Navigation.tsx
@@ -1,25 +1,22 @@
+import { useLinkStore } from "@/store/link";
 import { Button } from "@mui/material";
 import { useCallback } from "react";
-import { Link, useLocation } from "react-router";
 
 
 function Navigation() {
-    const { pathname } = useLocation();
+    const { link, updateLink } = useLinkStore();
 
     const btnProps = useCallback((itemlink: string) => {
         return ({
-            variant: pathname === itemlink ? 'contained' : 'outlined' as 'contained' | 'outlined',
+            variant: link === itemlink ? 'contained' : 'outlined' as 'contained' | 'outlined',
+            onClick: updateLink.bind(null, itemlink)
         });
-    }, [pathname]);
+    }, [link]);
 
     return (
         <nav className="p-2 border-b border-b-gray-300 flex flex-row gap-2">
-            <Link to="/">
-                <Button {...btnProps('/')}>SECS to Item</Button>
-            </Link>
-            <Link to="/item-to-secs">
-                <Button {...btnProps('/item-to-secs')}>Item To Secs</Button>
-            </Link>
+            <Button {...btnProps('/')}>SECS to Item</Button>
+            <Button {...btnProps('/item-to-secs')}>Item To Secs</Button>
         </nav>
     );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router'
 import App from './App.tsx'
 import './index.css'
 const basename = import.meta.env.MODE === "production" ? "/secs_parser_page" : "/";
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter basename={basename}>
       <App />
-    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
-const basename = import.meta.env.MODE === "production" ? "/secs_parser_page" : "/";
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/store/link.ts
+++ b/src/store/link.ts
@@ -9,7 +9,7 @@ type LinkAction = {
 }
 
 const useLinkStore = create<LinkState & LinkAction>((set) => ({
-    link: 'secs-to-item', // 초기 페이지?
+    link: '/', // 초기 페이지?
     updateLink: (new_link) => {
         set({link: new_link});
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,5 +14,5 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     }
   },
-  base: process.env.CI && "/secs_parser_page"
+  base: process.env.CI && "./"
 })


### PR DESCRIPTION
현재 페이지는 서브 경로 /secs_parser_page에 배포하는데, /secs_parser_page/sub 처럼 추가적인 sub 경로에 대한 라우팅을 요청했을 때 해당 경로를 찾지 못하는 문제 존재.

react-router을 이용하더라도 추가적인 장점이 크지 않으므로(url 라우팅 불가능하기 때문) 간단하게 만든 route 객체로 대체