### PR TITLE
fix: boolean이 true / false가 아닌 1byte 데이터로 처리할 수 있도록 수정

### DIFF
--- a/src/core/secs/component/comp_converter.spec.ts
+++ b/src/core/secs/component/comp_converter.spec.ts
@@ -64,7 +64,7 @@ describe('ComponentItemConverter', () => {
             
             const expected: Secs2Item = {
                 info: secsInfoMap.fromSML('BOOLEAN'),
-                data: [true, true]
+                data: [13, 42]
             };
 
             const result: Secs2Item = converter.convert(item);

--- a/src/core/secs/component/util/comp_data_parser.ts
+++ b/src/core/secs/component/util/comp_data_parser.ts
@@ -7,7 +7,6 @@ export class Secs2CompItemDataParser {
     constructor() {
         this.parseMap = new Map();
         this.parseMap.set('A', this.parseString);
-        this.parseMap.set('BOOLEAN', this.parseBoolean);
         
         this.parseMap.set('I8', this.parseBigint);
         this.parseMap.set('U8', this.parseBigint);
@@ -47,16 +46,7 @@ export class Secs2CompItemDataParser {
         }
         return items;
     }
-
-    private parseBoolean(item: string[]): boolean[] {
-        const items: boolean[] = [];
-        for (const data of item) {
-            if(!validateFloat(data)) throw new Error(`${data} cannot convert to boolean`);
-            items.push(parseInt(data) > 0);
-        }
-        return items;
-    }
-
+    
     private parseString(item: string[]): string {
         return item.join(''); // 띄어서 표현 가능하나 붙어 있는 것으로 간주.
     }

--- a/src/core/secs/converter/parser/ItemResolver.ts
+++ b/src/core/secs/converter/parser/ItemResolver.ts
@@ -44,9 +44,9 @@ export class ItemParseResolver {
     }
 
     private handleBoolean(reader: BufferReader, length: number) {
-        const data: boolean[] = [];
+        const data: number[] = [];
         for (let i = 0; i < length; i++) {
-            data.push(reader.readUInt8() > 0);
+            data.push(reader.readUInt8());
         }
         return data;
     }

--- a/src/core/secs/converter/parser/parser.spec.ts
+++ b/src/core/secs/converter/parser/parser.spec.ts
@@ -166,7 +166,7 @@ describe('SecsParser Test', () => {
 
             const expected: Secs2Item = {
                 info: secsInfoMap.fromSML('BOOLEAN'),
-                data: [true, false],
+                data: [240, 0],
             };
 
             const result = parser.parse(reader);

--- a/src/core/secs/converter/serializer/ItemResolver.ts
+++ b/src/core/secs/converter/serializer/ItemResolver.ts
@@ -44,7 +44,7 @@ export class ItemSerializeResolver {
 
     private handleBoolean(writer: BufferWriter, items: Secs2Item['data']) {
         for (const item of items!) {
-            writer.writeUInt8(item as boolean ? 1 : 0); // 'items'에 있는 데이터 사용
+            writer.writeUInt8(item as number); // 'items'에 있는 데이터 사용
         }
     }
 

--- a/src/core/secs/converter/serializer/serializer.spec.ts
+++ b/src/core/secs/converter/serializer/serializer.spec.ts
@@ -119,7 +119,7 @@ describe("Secs Serializer test", () => {
         it('Boolean 타입 데이터 직렬화', () => {
             const item: Secs2Item = {
                 info: secsInfoMap.fromSML('BOOLEAN'),
-                data: [true, false],
+                data: [240, 0],
             };
 
             const writer = new BufferWriter();
@@ -131,7 +131,7 @@ describe("Secs Serializer test", () => {
 
             expect(view.getUint8(0)).toBe(0b00100101); // Boolean type
             expect(view.getUint8(1)).toBe(0b00000010); // 2 elements
-            expect(view.getUint8(2)).toBe(0b00000001); // true
+            expect(view.getUint8(2)).toBe(0b11110000); // true
             expect(view.getUint8(3)).toBe(0b00000000); // false
         });
 

--- a/src/core/secs/item/type.d.ts
+++ b/src/core/secs/item/type.d.ts
@@ -10,7 +10,7 @@ export type Secs2ItemSML = 'L' | 'B' | 'BOOLEAN' | 'A' |
 type Secs2ItemDataType<T extends Secs2ItemSML = undefined> =
     T extends 'L' ? Secs2Item[] :
     T extends 'B' ? number[] :
-    T extends 'BOOLEAN' ? boolean[] :
+    T extends 'BOOLEAN' ? number[] :
     T extends 'A' ? string :
     T extends
     // 'J' | 


### PR DESCRIPTION
secs2 boolean type은 1 byte 데이터에 대해 0이면 false, 아니면 true로 간주한다. 이전에는 이러한 정의를 고려하여 내부적으로 true / false 값으로 관리하도록 구현했으나, item parse / serialize 과정에서 byte 데이터에 손실이 발생하는 문제가 있었다.

예를 들어, 240 = true인 boolean 변수를 내부 객체로 변환하면 true 정보만 남기 때문에, 이를 다시 byte message로 변환하면 1이 된다. 대부분의 시스템이 명세에 따라 동일한 true로 간주하더라도 240이라는 데이터에 손실이 발생하므로 동작을 수정할 필요가 있다고 생각하여 BOOLEAN 데이터를 내부적으로 1 byte 데이터 그대로 관리하기로 한다.

