### PR TITLE
refactor: hex editor이 input 요소를 이용하도록 변경

### DIFF
--- a/src/component/editor/HexEditor.tsx
+++ b/src/component/editor/HexEditor.tsx
@@ -167,13 +167,14 @@ function HexEditor({ bytes, updateItemHandler, deleteItemHandler, focusItemHandl
               "+"
             )}</div>
         </div>
-      </div>
-      <input className="w-full outline-0 opacity-0"
+        <input className="w-0 h-0 outline-0 opacity-0"
       ref={inputRef}
       value={""}
       onKeyDown={keyHandler}
       onChange={(e) => { e.preventDefault(); }}
       />
+      </div>
+      
     </>
   )
 };

--- a/src/component/editor/hooks/useFocus.ts
+++ b/src/component/editor/hooks/useFocus.ts
@@ -16,6 +16,7 @@ function useFocus(target: React.RefObject<HTMLElement>, options?: UseFocusOption
 
     const focusSelfHandler = () => {
         setFocus(true);
+        target.current?.focus();
         options?.onFocus?.();
     }
 


### PR DESCRIPTION
기존에 div 자체에서 keydown event를 식별해서 처리하던 방식을 input을 거치도록 변경.

현재는 모바일 환경에서 hex editor을 클릭해도 키보드가 등장하지 않아 입력이 불가능.
이를 해결해보기 위해 입력 시 input을 focus 해서 거치도록 구성해 봄.

대응 안될 시 virtualKeboard API 또는 가상 키보드 라이브러리 등 사용해 볼 예정